### PR TITLE
Add configurable AI models

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 # 复制环境变量模板
 cp env.example .env
 
-# 编辑 .env 文件，至少配置以下必需项：
+# 编辑 .env 文件，可自定义 AI 接口地址和模型，至少配置以下必需项：
 ```
 
 **必需配置项：**
@@ -42,10 +42,17 @@ DATABASE_URL=mysql+pymysql://username:password@localhost:3306/ai_diary_db
 
 # AI服务（至少配置一个）
 OPENAI_API_KEY=your-openai-api-key
-# 或者
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_VISION_MODEL=gpt-4-vision-preview
+# 或者配置Anthropic
 ANTHROPIC_API_KEY=your-anthropic-api-key
-# 或者
+ANTHROPIC_MODEL=claude-3-sonnet-20240229
+ANTHROPIC_VISION_MODEL=claude-3-vision-20240229
+# 或者配置Google Gemini
 GOOGLE_API_KEY=your-google-api-key
+GOOGLE_MODEL=gemini-pro
+GOOGLE_VISION_MODEL=gemini-pro-vision
 
 # 存储配置（开发环境可以使用本地存储）
 STORAGE_TYPE=local

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ cd ai-diary-app
 pip install -r requirements.txt
 ```
 
-3. 配置环境变量
+3. 配置环境变量（可在此自定义AI接口地址和模型）
 ```bash
 cp .env.example .env
-# 编辑 .env 文件，配置数据库、AI服务等参数
+# 编辑 .env 文件，自定义数据库、AI接口地址和模型等参数
 ```
 
 4. 初始化数据库

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):
@@ -20,8 +21,16 @@ class Settings(BaseSettings):
     # AI服务配置
     openai_api_key: Optional[str] = Field(default=None, env="OPENAI_API_KEY")
     openai_base_url: str = Field(default="https://api.openai.com/v1", env="OPENAI_BASE_URL")
+    openai_model: str = Field(default="gpt-3.5-turbo", env="OPENAI_MODEL")
+    openai_vision_model: str = Field(default="gpt-4-vision-preview", env="OPENAI_VISION_MODEL")
+
     anthropic_api_key: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
+    anthropic_model: str = Field(default="claude-3-sonnet-20240229", env="ANTHROPIC_MODEL")
+    anthropic_vision_model: str = Field(default="claude-3-vision-20240229", env="ANTHROPIC_VISION_MODEL")
+
     google_api_key: Optional[str] = Field(default=None, env="GOOGLE_API_KEY")
+    google_model: str = Field(default="gemini-pro", env="GOOGLE_MODEL")
+    google_vision_model: str = Field(default="gemini-pro-vision", env="GOOGLE_VISION_MODEL")
     
     # 对象存储配置
     storage_type: str = Field(default="s3", env="STORAGE_TYPE")

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -15,7 +15,7 @@ class AIService:
         # 初始化OpenAI客户端
         if settings.openai_api_key:
             openai.api_key = settings.openai_api_key
-            openai.base_url = settings.openai_base_url
+            openai.api_base = settings.openai_base_url
             self.openai_client = openai
         
         # 初始化Anthropic客户端
@@ -65,10 +65,10 @@ class AIService:
         """使用OpenAI分析"""
         try:
             if image_url:
-                # 如果有图片，使用GPT-4V
+                # 如果有图片，使用自定义视觉模型
                 response = await asyncio.to_thread(
                     self.openai_client.ChatCompletion.acreate,
-                    model="gpt-4-vision-preview",
+                    model=settings.openai_vision_model,
                     messages=[
                         {
                             "role": "user",
@@ -81,10 +81,10 @@ class AIService:
                     max_tokens=300
                 )
             else:
-                # 纯文字使用GPT-3.5
+                # 纯文字使用自定义模型
                 response = await asyncio.to_thread(
                     self.openai_client.ChatCompletion.acreate,
-                    model="gpt-3.5-turbo",
+                    model=settings.openai_model,
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=300
                 )
@@ -100,7 +100,7 @@ class AIService:
                 # Claude支持图片分析
                 response = await asyncio.to_thread(
                     self.anthropic_client.messages.create,
-                    model="claude-3-vision-20240229",
+                    model=settings.anthropic_vision_model,
                     max_tokens=300,
                     messages=[
                         {
@@ -115,7 +115,7 @@ class AIService:
             else:
                 response = await asyncio.to_thread(
                     self.anthropic_client.messages.create,
-                    model="claude-3-sonnet-20240229",
+                    model=settings.anthropic_model,
                     max_tokens=300,
                     messages=[{"role": "user", "content": prompt}]
                 )
@@ -127,7 +127,8 @@ class AIService:
     async def _analyze_with_google(self, prompt: str, image_url: Optional[str] = None) -> str:
         """使用Google Gemini分析"""
         try:
-            model = self.google_client.GenerativeModel('gemini-pro-vision' if image_url else 'gemini-pro')
+            model_name = settings.google_vision_model if image_url else settings.google_model
+            model = self.google_client.GenerativeModel(model_name)
             
             if image_url:
                 # 需要下载图片数据
@@ -174,7 +175,7 @@ class AIService:
             if self.openai_client:
                 response = await asyncio.to_thread(
                     self.openai_client.ChatCompletion.acreate,
-                    model="gpt-3.5-turbo",
+                    model=settings.openai_model,
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=800
                 )
@@ -182,13 +183,13 @@ class AIService:
             elif self.anthropic_client:
                 response = await asyncio.to_thread(
                     self.anthropic_client.messages.create,
-                    model="claude-3-sonnet-20240229",
+                    model=settings.anthropic_model,
                     max_tokens=800,
                     messages=[{"role": "user", "content": prompt}]
                 )
                 return response.content[0].text.strip()
             elif self.google_client:
-                model = self.google_client.GenerativeModel('gemini-pro')
+                model = self.google_client.GenerativeModel(settings.google_model)
                 response = await asyncio.to_thread(
                     model.generate_content,
                     prompt,

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,14 +160,26 @@ DATABASE_URL=mysql+pymysql://username:password@localhost:3306/ai_diary_db
 
 # AI服务配置（至少配置一个）
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_VISION_MODEL=gpt-4-vision-preview
 ANTHROPIC_API_KEY=your-anthropic-api-key
+ANTHROPIC_MODEL=claude-3-sonnet-20240229
+ANTHROPIC_VISION_MODEL=claude-3-vision-20240229
 GOOGLE_API_KEY=your-google-api-key
+GOOGLE_MODEL=gemini-pro
+GOOGLE_VISION_MODEL=gemini-pro-vision
 
 # 存储配置（至少配置一个）
 STORAGE_TYPE=s3  # s3, oss, local
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 AWS_S3_BUCKET=your-bucket-name
+# 阿里云OSS，可选
+OSS_ACCESS_KEY_ID=your-oss-access-key
+OSS_ACCESS_KEY_SECRET=your-oss-secret-key
+OSS_ENDPOINT=your-oss-endpoint
+OSS_BUCKET_NAME=your-oss-bucket
 ```
 
 ## 开发指南

--- a/env.example
+++ b/env.example
@@ -1,57 +1,57 @@
-# 应用配置
+# 基础配置(必填)
 APP_NAME=AI日记应用
 DEBUG=true
 SECRET_KEY=your-secret-key-here-make-it-long-and-random
+JWT_SECRET_KEY=your-jwt-secret-key-here
 API_V1_STR=/api/v1
-
-# 数据库配置
 DATABASE_URL=mysql+pymysql://username:password@localhost:3306/ai_diary_db
-DATABASE_POOL_SIZE=10
-DATABASE_MAX_OVERFLOW=20
 
-# Redis配置
+# Redis配置(可选)
 REDIS_URL=redis://localhost:6379/0
 
-# AI服务配置
+# AI服务配置(至少启用一个)
+# OpenAI
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_VISION_MODEL=gpt-4-vision-preview
+# Anthropic
 ANTHROPIC_API_KEY=your-anthropic-api-key
+ANTHROPIC_MODEL=claude-3-sonnet-20240229
+ANTHROPIC_VISION_MODEL=claude-3-vision-20240229
+# Google Gemini
 GOOGLE_API_KEY=your-google-api-key
+GOOGLE_MODEL=gemini-pro
+GOOGLE_VISION_MODEL=gemini-pro-vision
 
-# 对象存储配置
-STORAGE_TYPE=s3  # s3, oss, local
+# 对象存储配置(可选: s3 | oss | local)
+STORAGE_TYPE=s3
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 AWS_REGION=us-east-1
 AWS_S3_BUCKET=your-bucket-name
-
-# 阿里云OSS配置
+# 阿里云OSS
 OSS_ACCESS_KEY_ID=your-oss-access-key
 OSS_ACCESS_KEY_SECRET=your-oss-secret-key
 OSS_ENDPOINT=your-oss-endpoint
 OSS_BUCKET_NAME=your-oss-bucket
 
-# Telegram配置
+# Telegram(可选)
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_WEBHOOK_URL=https://your-domain.com/webhook
 
-# 日志配置
+# 日志
 LOG_LEVEL=INFO
 LOG_FORMAT=json
 
-# 安全配置
-JWT_SECRET_KEY=your-jwt-secret-key-here
-JWT_ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=30
-
-# 文件上传配置
-MAX_FILE_SIZE=10485760  # 10MB
+# 文件上传
+MAX_FILE_SIZE=10485760
 ALLOWED_IMAGE_TYPES=image/jpeg,image/png,image/gif,image/webp
 
-# 任务调度配置
+# 任务调度
 CELERY_BROKER_URL=redis://localhost:6379/1
 CELERY_RESULT_BACKEND=redis://localhost:6379/1
 
-# 监控配置
+# 监控
 PROMETHEUS_ENABLED=true
-METRICS_PORT=9090 
+METRICS_PORT=9090

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,14 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+
+# 最小化环境变量，保证配置加载
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 
 from app.main import app
 from app.core.database import Base, get_db


### PR DESCRIPTION
## Summary
- allow configuring AI models and API base URLs
- clarify required/optional fields in example env file
- document new configuration options in dev guide and quickstart
- update README instructions
- fix tests to set minimal env variables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d9c9d3e883328e913904f3747b27