### PR TITLE
Fix allowed image types env parsing

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Union
 from pydantic_settings import BaseSettings
 from pydantic import Field, field_validator
 
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
     
     # 文件上传配置
     max_file_size: int = Field(default=10485760, env="MAX_FILE_SIZE")  # 10MB
-    allowed_image_types: List[str] = Field(
+    allowed_image_types: Union[List[str], str] = Field(
         default_factory=lambda: ["image/jpeg", "image/png", "image/gif", "image/webp"],
         env="ALLOWED_IMAGE_TYPES",
     )

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -15,8 +15,11 @@ from app.core.config import settings
 def init_database():
     """初始化数据库"""
     print("正在初始化数据库...")
-    
+
     try:
+        # 导入所有模型，确保元数据已被填充
+        from app.models import user, moment, diary  # noqa: F401
+
         # 创建所有表
         Base.metadata.create_all(bind=engine)
         print("✓ 数据库表创建成功")


### PR DESCRIPTION
## Summary
- allow non-JSON `ALLOWED_IMAGE_TYPES` environment variable

## Testing
- `pytest -q`
- `python scripts/init_db.py` *(fails: missing required env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6885e7fa6da88332be049d79604478aa