### PR TITLE
Add basic AI diary web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+uploads/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# AI Diary
+
+一个使用AI自动整理的个人日记应用。用户可以上传照片和文字，系统会调用自定义的AI接口分析内容并保存。每天零点后自动汇总前一天的内容生成日记，可通过网页查看、API获取以及 Telegram 推送三种方式访问。
+
+## 安装
+
+1. 安装依赖：
+
+```bash
+pip install -r requirements.txt
+```
+
+2. 创建数据库并初始化表结构：
+
+```python
+import db
+db.init_db()
+```
+
+3. 配置环境变量（可在 `.env` 文件中设置）：
+
+```
+DB_HOST, DB_USER, DB_PASSWORD, DB_NAME  # MySQL 配置
+DIARY_PASSWORD                          # 登录密码（1~4位）
+AI_API_URL, AI_API_KEY, AI_MODEL        # AI 接口配置
+TELEGRAM_BOT_KEY, TELEGRAM_CHAT_ID      # Telegram 推送配置
+SECRET_KEY                              # Flask 会话密钥
+```
+
+## 运行
+
+```bash
+python app.py
+```
+
+访问 `http://localhost:8000` 使用密码登录并记录日记。
+
+## 每日汇总
+
+配置定时任务每天零点运行：
+
+```bash
+python daily_summary.py
+```
+
+该脚本会整理前一天的所有记录，生成总结并推送到 Telegram。
+
+## API
+
+登陆后可访问 `/api/diary?days=30` 获取最近 30 天内的原始记录。
+
+## 文件结构
+
+- `app.py` Web 应用入口
+- `daily_summary.py` 每日汇总脚本
+- `db.py` 数据库相关函数
+- `ai.py` AI 调用封装
+- `telegram_util.py` Telegram 推送
+- `templates/` 页面模板
+- `static/` 静态资源

--- a/ai.py
+++ b/ai.py
@@ -1,0 +1,57 @@
+import requests
+import config
+
+
+def analyze_entry(text, image_url=None):
+    messages = []
+    if text:
+        messages.append({"role": "user", "content": text})
+    if image_url:
+        messages.append({
+            "role": "user",
+            "content": {
+                "type": "image_url",
+                "image_url": image_url
+            }
+        })
+
+    payload = {
+        "model": config.AI_MODEL,
+        "messages": messages
+    }
+    headers = {
+        "Authorization": f"Bearer {config.AI_API_KEY}",
+        "Content-Type": "application/json"
+    }
+    try:
+        r = requests.post(config.AI_API_URL, json=payload, headers=headers, timeout=30)
+        r.raise_for_status()
+        data = r.json()
+        return data['choices'][0]['message']['content']
+    except Exception as e:
+        return f"AI解析失败: {e}"
+
+
+def summarize_day(entries):
+    content = "\n".join(
+        f"{e['timestamp']}: {e['content_text']} {e['analysis']}" for e in entries
+    )
+    messages = [
+        {"role": "system", "content": "你是一个日记助手，帮用户总结每天的活动"},
+        {"role": "user", "content": content}
+    ]
+    payload = {
+        "model": config.AI_MODEL,
+        "messages": messages
+    }
+    headers = {
+        "Authorization": f"Bearer {config.AI_API_KEY}",
+        "Content-Type": "application/json"
+    }
+    try:
+        r = requests.post(config.AI_API_URL, json=payload, headers=headers, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        return data['choices'][0]['message']['content']
+    except Exception as e:
+        return f"AI总结失败: {e}"

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, render_template, request, redirect, url_for, session, send_from_directory, jsonify
+from datetime import datetime, date, timedelta
+import os
+
+import db
+import ai
+import config
+
+app = Flask(__name__)
+app.secret_key = os.getenv('SECRET_KEY', 'secret')
+UPLOAD_FOLDER = 'uploads'
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+def check_login():
+    return session.get('logged_in')
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        password = request.form.get('password')
+        if password == config.PASSWORD:
+            session['logged_in'] = True
+            return redirect(url_for('index'))
+    if not check_login():
+        return render_template('login.html')
+    summaries = db.get_summaries()
+    return render_template('index.html', summaries=summaries)
+
+
+@app.route('/submit', methods=['GET', 'POST'])
+def submit():
+    if not check_login():
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        text = request.form.get('text')
+        file = request.files.get('image')
+        image_path = None
+        if file and file.filename:
+            image_path = os.path.join(UPLOAD_FOLDER, file.filename)
+            file.save(image_path)
+        image_url = None
+        if image_path:
+            image_url = request.url_root.rstrip('/') + url_for('uploaded_file', filename=file.filename)
+        analysis = ai.analyze_entry(text, image_url=image_url)
+        db.add_entry(text, image_path, analysis)
+        return redirect(url_for('submit'))
+    return render_template('submit.html')
+
+
+@app.route('/uploads/<path:filename>')
+def uploaded_file(filename):
+    return send_from_directory(UPLOAD_FOLDER, filename)
+
+
+@app.route('/api/diary')
+def api_diary():
+    if not check_login():
+        return jsonify({'error': 'unauthorized'}), 401
+    days = int(request.args.get('days', 30))
+    days = min(days, 30)
+    end_dt = datetime.now()
+    start_dt = end_dt - timedelta(days=days)
+    entries = db.get_entries_between(start_dt, end_dt)
+    return jsonify(entries)
+
+
+if __name__ == '__main__':
+    db.init_db()
+    app.run(host='0.0.0.0', port=8000, debug=True)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Database configuration
+DB_HOST = os.getenv('DB_HOST', 'localhost')
+DB_USER = os.getenv('DB_USER', 'diary')
+DB_PASSWORD = os.getenv('DB_PASSWORD', 'password')
+DB_NAME = os.getenv('DB_NAME', 'diary')
+
+# Simple password (1-4 digits)
+PASSWORD = os.getenv('DIARY_PASSWORD', '1234')
+
+# AI API configuration
+AI_API_URL = os.getenv('AI_API_URL', 'https://api.openai.com/v1/chat/completions')
+AI_API_KEY = os.getenv('AI_API_KEY', '')
+AI_MODEL = os.getenv('AI_MODEL', 'gpt-3.5-turbo')
+
+# Telegram configuration
+TELEGRAM_BOT_KEY = os.getenv('TELEGRAM_BOT_KEY', '')
+TELEGRAM_CHAT_ID = os.getenv('TELEGRAM_CHAT_ID', '')

--- a/daily_summary.py
+++ b/daily_summary.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta, date
+import db
+import ai
+import telegram_util
+
+
+def run():
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    start_dt = datetime.combine(yesterday, datetime.min.time())
+    end_dt = datetime.combine(today, datetime.min.time())
+
+    entries = db.get_entries_between(start_dt, end_dt)
+    if not entries:
+        return
+    summary = ai.summarize_day(entries)
+    db.save_summary(yesterday, summary)
+    telegram_util.send_message(f"{yesterday} 的日记总结:\n{summary}")
+
+
+if __name__ == '__main__':
+    db.init_db()
+    run()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,87 @@
+import mysql.connector
+from mysql.connector import Error
+from datetime import datetime, date
+import config
+
+
+def get_connection():
+    return mysql.connector.connect(
+        host=config.DB_HOST,
+        user=config.DB_USER,
+        password=config.DB_PASSWORD,
+        database=config.DB_NAME,
+        autocommit=True
+    )
+
+
+def init_db():
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        """CREATE TABLE IF NOT EXISTS entries (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                content_text TEXT,
+                image_path VARCHAR(255),
+                analysis TEXT,
+                timestamp DATETIME
+            )"""
+    )
+    cursor.execute(
+        """CREATE TABLE IF NOT EXISTS summaries (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                day DATE UNIQUE,
+                summary_text TEXT
+            )"""
+    )
+    cursor.close()
+    conn.close()
+
+
+def add_entry(text, image_path, analysis):
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO entries (content_text, image_path, analysis, timestamp) VALUES (%s, %s, %s, %s)",
+        (text, image_path, analysis, datetime.now())
+    )
+    cursor.close()
+    conn.close()
+
+
+def get_entries_between(start_dt, end_dt):
+    conn = get_connection()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute(
+        "SELECT * FROM entries WHERE timestamp >= %s AND timestamp < %s ORDER BY timestamp",
+        (start_dt, end_dt)
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return rows
+
+
+def save_summary(day: date, summary_text: str):
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        "REPLACE INTO summaries (day, summary_text) VALUES (%s, %s)",
+        (day, summary_text)
+    )
+    cursor.close()
+    conn.close()
+
+
+def get_summaries(limit=365):
+    conn = get_connection()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute(
+        "SELECT * FROM summaries ORDER BY day DESC LIMIT %s",
+        (limit,)
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return rows
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+mysql-connector-python
+requests
+python-dotenv

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; background: #f2f2f2; }
+.container { width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; }
+input, textarea { width: 100%; margin-bottom: 10px; }
+button { padding: 5px 10px; }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 15px; }

--- a/telegram_util.py
+++ b/telegram_util.py
@@ -1,0 +1,16 @@
+import requests
+import config
+
+
+def send_message(text):
+    if not config.TELEGRAM_BOT_KEY or not config.TELEGRAM_CHAT_ID:
+        return
+    url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_KEY}/sendMessage"
+    payload = {
+        "chat_id": config.TELEGRAM_CHAT_ID,
+        "text": text
+    }
+    try:
+        requests.post(url, data=payload, timeout=30)
+    except Exception:
+        pass

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<title>我的日记</title>
+<link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+<h2>我的日记汇总</h2>
+<a href="/submit">记录新的内容</a>
+<ul>
+{% for s in summaries %}
+<li><strong>{{ s.day }}</strong><p>{{ s.summary_text }}</p></li>
+{% else %}
+<li>暂无日记</li>
+{% endfor %}
+</ul>
+</div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<title>登录</title>
+<link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+<h2>日记登录</h2>
+<form method="post">
+    <input type="password" name="password" maxlength="4" required>
+    <button type="submit">登录</button>
+</form>
+</div>
+</body>
+</html>

--- a/templates/submit.html
+++ b/templates/submit.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<title>记录日记</title>
+<link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+<h2>记录日记</h2>
+<form method="post" enctype="multipart/form-data">
+    <textarea name="text" rows="4" cols="50" placeholder="输入文字"></textarea><br>
+    <input type="file" name="image" accept="image/*"><br>
+    <button type="submit">提交</button>
+</form>
+<a href="/">返回</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up Flask web app with MySQL backend
- add AI integration and Telegram push utility
- provide daily summary script
- add basic HTML templates and CSS
- include installation instructions in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`
- `python app.py` *(fails: Can't connect to MySQL server)*
- `python daily_summary.py` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68862ec8ae688330a2ffb160e736dfa2