### PR TITLE
Improve service diagnostics and settings UI

### DIFF
--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -21,15 +21,19 @@ def require_auth(f):
 def test_ai():
     """测试AI连接"""
     try:
-        data = request.json
+        data = request.json or {}
         test_text = data.get('text', '测试文本')
-        
-        # 重新加载AI配置
-        ai_service._load_config()
-        
-        # 测试AI分析
+
+        # 先测试连通性
+        success, message = ai_service.test_connection()
+        if not success:
+            return jsonify({'success': False, 'message': message}), 500
+
         result = ai_service.analyze_entry(test_text)
-        
+
+        if result.startswith('AI分析失败') or result == 'AI服务未配置':
+            return jsonify({'success': False, 'message': result}), 500
+
         return jsonify({
             'success': True,
             'message': 'AI测试成功',
@@ -46,28 +50,18 @@ def test_telegram():
     try:
         # 重新加载Telegram配置
         telegram_service._load_config()
-        
+
         # 测试连接
         success, message = telegram_service.test_connection()
-        
-        if success:
-            # 发送测试消息
-            test_success = telegram_service.send_message("🧪 这是一条测试消息，来自杯子日记")
-            if test_success:
-                return jsonify({
-                    'success': True,
-                    'message': '测试消息发送成功'
-                })
-            else:
-                return jsonify({
-                    'success': False,
-                    'message': '连接成功但发送消息失败'
-                }), 500
+
+        if not success:
+            return jsonify({'success': False, 'message': message}), 500
+
+        test_success = telegram_service.send_message("🧪 这是一条测试消息，来自杯子日记")
+        if test_success:
+            return jsonify({'success': True, 'message': '测试消息发送成功'})
         else:
-            return jsonify({
-                'success': False,
-                'message': message
-            }), 500
+            return jsonify({'success': False, 'message': '连接成功但发送消息失败'}), 500
             
     except Exception as e:
         return jsonify({'success': False, 'message': f'Telegram测试失败: {str(e)}'}), 500

--- a/src/services/ai_service.py
+++ b/src/services/ai_service.py
@@ -9,6 +9,19 @@ class AIService:
         self.api_url = None
         self.api_key = None
         self.model = None
+
+    def test_connection(self):
+        """测试与AI服务的连通性"""
+        # 重新加载配置
+        self._load_config()
+        if not self.client:
+            return False, "AI服务未配置"
+        try:
+            # 调用一个轻量级接口验证连接
+            self.client.models.list()
+            return True, "连接成功"
+        except Exception as e:
+            return False, f"连接异常: {str(e)}"
     
     def _load_config(self):
         """加载AI配置"""

--- a/src/static/config.html
+++ b/src/static/config.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>配置设置</title>
     <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
+        body { font-family: Arial, sans-serif; padding: 20px; animation: fadeIn .3s ease; }
         label { display:block; margin-top:10px; }
         input[type="text"], textarea { width: 100%; padding: 6px; margin-top: 4px; }
         button { margin-top: 15px; padding: 8px 16px; }
         #login-section, #config-section { max-width: 600px; margin:auto; }
+        @keyframes fadeIn { from {opacity:0;} to {opacity:1;} }
     </style>
 </head>
 <body>
@@ -23,6 +24,7 @@
 </div>
 <div id="config-section" style="display:none;">
     <h2>系统配置</h2>
+    <button onclick="goBack()" style="float:right;">返回</button>
     <label>AI API地址
         <input type="text" id="ai_api_url" />
     </label>
@@ -48,6 +50,7 @@
         <input type="checkbox" id="telegram_enabled" /> 启用Telegram推送
     </label>
     <button onclick="saveConfig()">保存配置</button>
+    <button onclick="testAI()">测试AI</button>
     <button onclick="testTelegram()">测试Telegram</button>
     <p id="config-msg"></p>
 </div>
@@ -114,10 +117,22 @@ async function saveConfig() {
     }
     document.getElementById('config-msg').textContent = '保存成功';
 }
+async function testAI() {
+    const res = await fetch('/api/admin/test-ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: '连接测试' })
+    });
+    const data = await res.json();
+    document.getElementById('config-msg').textContent = data.message || data.result || '';
+}
 async function testTelegram() {
     const res = await fetch('/api/admin/test-telegram', { method: 'POST' });
     const data = await res.json();
     document.getElementById('config-msg').textContent = data.message;
+}
+function goBack(){
+    window.location.href = '/';
 }
 checkAuth();
 </script>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <a href="/config.html" style="position:fixed;top:10px;right:10px;z-index:1000;background:#fff;padding:6px 10px;border-radius:4px;text-decoration:none;border:1px solid #ccc;">配置</a>
+    <a href="/config.html" id="settings-link" style="position:absolute;top:10px;right:10px;background:#fff;padding:6px 10px;border-radius:4px;text-decoration:none;border:1px solid #ccc;">设置</a>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add AI service `test_connection` method
- improve admin endpoints for AI and Telegram tests
- tweak `config.html` with back button, fade animation, and AI test
- rename config link to `设置` in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887660852848330a76f57b320d85c32