### PR TITLE
Improve settings UI overlay

### DIFF
--- a/src/static/config.html
+++ b/src/static/config.html
@@ -132,7 +132,11 @@ async function testTelegram() {
     document.getElementById('config-msg').textContent = data.message;
 }
 function goBack(){
-    window.location.href = '/';
+    if (window.parent && window.parent.closeSettings) {
+        window.parent.closeSettings();
+    } else {
+        window.location.href = '/';
+    }
 }
 checkAuth();
 </script>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -7,9 +7,32 @@
     <title>杯子日记</title>
     <script type="module" crossorigin src="/assets/index-DUaNkWBt.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-oWMHbS2h.css">
+  <style>
+    #config-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,0.95);z-index:9999;display:none;animation:fadeIn 0.3s;}
+    @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+  </style>
   </head>
   <body>
     <div id="root"></div>
-    <a href="/config.html" id="settings-link" style="position:absolute;top:10px;right:10px;background:#fff;padding:6px 10px;border-radius:4px;text-decoration:none;border:1px solid #ccc;">设置</a>
+    <div id="config-overlay">
+      <iframe src="/config.html" style="width:100%;height:100%;border:none;"></iframe>
+    </div>
+    <script>
+      function openSettings(){document.getElementById('config-overlay').style.display='block';}
+      function closeSettings(){document.getElementById('config-overlay').style.display='none';}
+      function addSettingsButton(){
+        const logoutBtn=[...document.querySelectorAll('button')].find(b=>b.textContent.trim()==='登出');
+        if(logoutBtn && !document.getElementById('settings-button')){
+          const btn=logoutBtn.cloneNode(true);
+          btn.id='settings-button';
+          btn.textContent='设置';
+          btn.addEventListener('click',openSettings);
+          logoutBtn.parentNode.insertBefore(btn,logoutBtn.nextSibling);
+        }
+      }
+      const ob=new MutationObserver(addSettingsButton);
+      ob.observe(document.getElementById('root'),{childList:true,subtree:true});
+      addSettingsButton();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add Settings overlay UI in `index.html`
- insert Settings button next to Logout via script
- ensure Settings overlay shows on top and fades in
- allow closing overlay from `config.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688769c83c708330bed23f038088904e