### PR TITLE
Align logout and settings buttons on right

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,8 @@
   <style>
     #config-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,0.95);z-index:9999;display:none;animation:fadeIn 0.3s;}
     @keyframes fadeIn{from{opacity:0;}to{opacity:1;}}
+    #button-container{display:flex;justify-content:flex-end;gap:0.5rem;}
+    @media(max-width:640px){#button-container{padding-right:0.5rem;}}
   </style>
   </head>
   <body>
@@ -28,6 +30,10 @@
           btn.textContent='设置';
           btn.addEventListener('click',openSettings);
           logoutBtn.parentNode.insertBefore(btn,logoutBtn.nextSibling);
+        }
+        if(logoutBtn){
+          const container=logoutBtn.parentNode;
+          container.id='button-container';
         }
       }
       const ob=new MutationObserver(addSettingsButton);


### PR DESCRIPTION
## Summary
- tweak index HTML to align logout and settings button on the right
- add responsive spacing for mobile devices

## Testing
- `find src -name '*.py' | xargs -I {} python -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_68876c09003c83309fdb7cda6517ea68