### PR TITLE
Fix scheduler timezone and persist login

### DIFF
--- a/src/models/diary.py
+++ b/src/models/diary.py
@@ -1,5 +1,11 @@
 from src.models.user import db
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def beijing_now():
+    """Return current time in Asia/Shanghai timezone"""
+    return datetime.now(ZoneInfo("Asia/Shanghai"))
 import json
 
 class DiaryEntry(db.Model):
@@ -7,11 +13,11 @@ class DiaryEntry(db.Model):
     __tablename__ = 'diary_entries'
     
     id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    timestamp = db.Column(db.DateTime, default=beijing_now, nullable=False)
     text_content = db.Column(db.Text)  # 用户输入的文字内容
     image_path = db.Column(db.String(255))  # 图片存储路径
     ai_analysis = db.Column(db.Text)  # AI分析结果
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=beijing_now)
     
     def __repr__(self):
         return f'<DiaryEntry {self.id} at {self.timestamp}>'
@@ -34,7 +40,7 @@ class DailySummary(db.Model):
     date = db.Column(db.Date, unique=True, nullable=False)  # 日期（年-月-日）
     summary_content = db.Column(db.Text, nullable=False)  # AI汇总的日记内容
     entry_count = db.Column(db.Integer, default=0)  # 当日条目数量
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=beijing_now)
     
     def __repr__(self):
         return f'<DailySummary {self.date}>'
@@ -56,8 +62,8 @@ class Config(db.Model):
     key = db.Column(db.String(100), unique=True, nullable=False)
     value = db.Column(db.Text)
     description = db.Column(db.String(255))
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=beijing_now)
+    updated_at = db.Column(db.DateTime, default=beijing_now, onupdate=beijing_now)
     
     def __repr__(self):
         return f'<Config {self.key}>'
@@ -78,8 +84,8 @@ class Auth(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     password_hash = db.Column(db.String(255), nullable=False)  # 密码哈希
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=beijing_now)
+    updated_at = db.Column(db.DateTime, default=beijing_now, onupdate=beijing_now)
     
     def __repr__(self):
         return f'<Auth {self.id}>'

--- a/src/routes/diary.py
+++ b/src/routes/diary.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, jsonify, request, session
 from werkzeug.utils import secure_filename
-from src.models.diary import DiaryEntry, DailySummary, db
+from src.models.diary import DiaryEntry, DailySummary, db, beijing_now
 from src.services.ai_service import ai_service
 from datetime import datetime, date, timedelta
+from zoneinfo import ZoneInfo
 import os
 import uuid
 import threading
@@ -70,7 +71,7 @@ def create_entry():
         entry = DiaryEntry(
             text_content=text_content,
             image_path=image_path,
-            timestamp=datetime.utcnow()
+            timestamp=beijing_now()
         )
         
         db.session.add(entry)
@@ -244,7 +245,7 @@ def get_summary(date_str):
 def get_today_countdown():
     """获取距离今日结束的倒计时"""
     try:
-        now = datetime.now()
+        now = datetime.now(ZoneInfo("Asia/Shanghai"))
         # 计算到明天0点的时间
         tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         remaining = tomorrow - now

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -1,6 +1,7 @@
 import threading
 import time
 from datetime import datetime, date, timedelta
+from zoneinfo import ZoneInfo
 from src.models.diary import DiaryEntry, DailySummary, db
 from src.services.ai_service import ai_service
 from src.services.telegram_service import telegram_service
@@ -36,7 +37,7 @@ class SchedulerService:
         with self.app.app_context():
             while self.running:
                 try:
-                    current_time = datetime.now()
+                    current_time = datetime.now(ZoneInfo("Asia/Shanghai"))
                     current_date = current_time.date()
 
                     # 检查是否到了新的一天（凌晨0点后）

--- a/src/static/config.html
+++ b/src/static/config.html
@@ -112,7 +112,7 @@
 async function checkAuth() {
     const loginSection = document.getElementById('login-section');
     const configSection = document.getElementById('config-section');
-    const res = await fetch('/api/auth/check');
+    const res = await fetch('/api/auth/check', { credentials: 'include' });
     const data = await res.json();
     if (data.authenticated) {
         loginSection.classList.add('hidden');
@@ -145,6 +145,7 @@ async function login() {
         const res = await fetch('/api/auth/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
             body: JSON.stringify({ password })
         });
         const data = await res.json();
@@ -164,7 +165,7 @@ async function login() {
 
 async function loadConfig() {
     try {
-        const res = await fetch('/api/configs');
+        const res = await fetch('/api/configs', { credentials: 'include' });
         if (!res.ok) throw new Error(`无法加载配置: ${res.statusText}`);
         const data = await res.json();
         if (data.success) {
@@ -211,6 +212,7 @@ async function saveConfig() {
         const res = await fetch('/api/configs', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
             body: JSON.stringify(configs)
         });
         const data = await res.json();
@@ -238,6 +240,7 @@ async function testAI() {
         const res = await fetch('/api/admin/test-ai', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
             body: JSON.stringify({ text: '连接测试' })
         });
         const data = await res.json();
@@ -262,7 +265,7 @@ async function testTelegram() {
     showToast('正在测试 Telegram 连接...');
 
     try {
-        const res = await fetch('/api/admin/test-telegram', { method: 'POST' });
+        const res = await fetch('/api/admin/test-telegram', { method: 'POST', credentials: 'include' });
         const data = await res.json();
         if (res.ok && data.success) {
             showToast(`Telegram 测试成功: ${data.message}`);

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI日记</title>
     <script type="module" crossorigin src="/assets/index-DUaNkWBt.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-oWMHbS2h.css">
   <style>
     #config-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,0.95);z-index:9999;display:none;animation:fadeIn 0.3s;}
@@ -48,6 +49,15 @@
       const ob=new MutationObserver(addSettingsButton);
       ob.observe(document.getElementById('root'),{childList:true,subtree:true});
       addSettingsButton();
+      function renderMarkdown(){
+        document.querySelectorAll('.markdown').forEach(el=>{
+          el.innerHTML=marked.parse(el.textContent);
+          el.classList.remove('markdown');
+        });
+      }
+      const mdObserver=new MutationObserver(renderMarkdown);
+      mdObserver.observe(document.getElementById('root'),{childList:true,subtree:true});
+      renderMarkdown();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- use Asia/Shanghai timezone for scheduler, countdown and timestamps
- include credentials in config page requests
- render markdown content using marked.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688807d3c620833090c7113c6b46fbda