### PR TITLE
Add network-based Beijing time

### DIFF
--- a/src/models/diary.py
+++ b/src/models/diary.py
@@ -1,5 +1,6 @@
 from src.models.user import db
 from datetime import datetime
+from src.services.time_service import time_service
 import json
 
 class DiaryEntry(db.Model):
@@ -7,11 +8,11 @@ class DiaryEntry(db.Model):
     __tablename__ = 'diary_entries'
     
     id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    timestamp = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time(), nullable=False)
     text_content = db.Column(db.Text)  # 用户输入的文字内容
     image_path = db.Column(db.String(255))  # 图片存储路径
     ai_analysis = db.Column(db.Text)  # AI分析结果
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time())
     
     def __repr__(self):
         return f'<DiaryEntry {self.id} at {self.timestamp}>'
@@ -34,7 +35,7 @@ class DailySummary(db.Model):
     date = db.Column(db.Date, unique=True, nullable=False)  # 日期（年-月-日）
     summary_content = db.Column(db.Text, nullable=False)  # AI汇总的日记内容
     entry_count = db.Column(db.Integer, default=0)  # 当日条目数量
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time())
     
     def __repr__(self):
         return f'<DailySummary {self.date}>'
@@ -56,8 +57,8 @@ class Config(db.Model):
     key = db.Column(db.String(100), unique=True, nullable=False)
     value = db.Column(db.Text)
     description = db.Column(db.String(255))
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time())
+    updated_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time(), onupdate=lambda: time_service.get_beijing_time())
     
     def __repr__(self):
         return f'<Config {self.key}>'
@@ -78,8 +79,8 @@ class Auth(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     password_hash = db.Column(db.String(255), nullable=False)  # 密码哈希
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time())
+    updated_at = db.Column(db.DateTime, default=lambda: time_service.get_beijing_time(), onupdate=lambda: time_service.get_beijing_time())
     
     def __repr__(self):
         return f'<Auth {self.id}>'

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -4,6 +4,7 @@ from src.services.ai_service import ai_service
 from src.services.telegram_service import telegram_service
 from src.services.scheduler_service import scheduler_service
 from datetime import datetime, date
+from src.services.time_service import time_service
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -138,7 +139,7 @@ def system_status():
                 'ai_configured': ai_configured,
                 'telegram_configured': telegram_configured,
                 'scheduler_running': scheduler_running,
-                'timestamp': datetime.now().isoformat()
+                'timestamp': time_service.get_beijing_time().isoformat()
             }
         })
         

--- a/src/routes/diary.py
+++ b/src/routes/diary.py
@@ -3,6 +3,7 @@ from werkzeug.utils import secure_filename
 from src.models.diary import DiaryEntry, DailySummary, db
 from src.services.ai_service import ai_service
 from datetime import datetime, date, timedelta
+from src.services.time_service import time_service
 import os
 import uuid
 import threading
@@ -70,7 +71,7 @@ def create_entry():
         entry = DiaryEntry(
             text_content=text_content,
             image_path=image_path,
-            timestamp=datetime.utcnow()
+            timestamp=time_service.get_beijing_time()
         )
         
         db.session.add(entry)
@@ -244,7 +245,7 @@ def get_summary(date_str):
 def get_today_countdown():
     """获取距离今日结束的倒计时"""
     try:
-        now = datetime.now()
+        now = time_service.get_beijing_time()
         # 计算到明天0点的时间
         tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         remaining = tomorrow - now

--- a/src/services/time_service.py
+++ b/src/services/time_service.py
@@ -1,0 +1,23 @@
+import requests
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+class TimeService:
+    API_URL = "http://worldtimeapi.org/api/timezone/Asia/Shanghai"
+
+    def get_beijing_time(self):
+        """Fetch current Beijing time from the network.
+        If network request fails, fall back to local time in Asia/Shanghai zone.
+        """
+        try:
+            response = requests.get(self.API_URL, timeout=5)
+            response.raise_for_status()
+            data = response.json()
+            dt_str = data.get("datetime")
+            if dt_str:
+                return datetime.fromisoformat(dt_str).astimezone(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        except Exception:
+            pass
+        return datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+
+time_service = TimeService()


### PR DESCRIPTION
## Summary
- add a `time_service` that fetches Beijing time from `worldtimeapi.org`
- use `time_service` in diary entry creation and countdown
- use `time_service` for system status timestamp
- default DB timestamps to network-based Beijing time

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68881c3bfffc8330805fa38301d0fea2