### PR TITLE
Implement markdown rendering for AI output

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -51,8 +51,10 @@
       addSettingsButton();
 
       function renderMarkdown() {
-        const analysisElements = document.querySelectorAll('.ai-analysis-content');
-        analysisElements.forEach(el => {
+        const elements = document.querySelectorAll(
+          '.ai-analysis-content, [data-markdown]'
+        );
+        elements.forEach(el => {
           if (!el.dataset.rendered) {
             el.innerHTML = marked.parse(el.textContent || '');
             el.dataset.rendered = 'true';


### PR DESCRIPTION
## Summary
- extend `renderMarkdown` function to look for `[data-markdown]` elements
- keep using `marked` to convert AI text to HTML on the fly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688840572c6083309b7bce2ef23a39ba