### PR TITLE
feat: add mcp memory clear all

### DIFF
--- a/src/static/js/mcp.js
+++ b/src/static/js/mcp.js
@@ -385,9 +385,15 @@ class MCPManager {
         if (!confirm('确定要清空所有记忆吗？此操作不可撤销！')) {
             return;
         }
+        const data = await this.apiRequest('/api/mcp/memories/clear', {
+            method: 'DELETE'
+        });
 
-        // 这里需要实现清空所有记忆的API
-        this.showAlert('功能开发中', 'warning');
+        if (data) {
+            this.showAlert('记忆已全部清空', 'success');
+            this.loadMemoryStats();
+            this.loadMemories();
+        }
     }
 
     showAddServerModal() {


### PR DESCRIPTION
## Summary
- add backend endpoint to clear all user memories
- wire frontend to call new memory-clear API and refresh stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953a624c1883309f0374a5cca9a8b0