### PR TITLE
Use logging for diagnostic messages

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,12 @@
 import os
 import sys
 import asyncio
+import logging
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+logging.basicConfig(level=logging.INFO, encoding='utf-8')
+logger = logging.getLogger(__name__)
 
 from flask import Flask, send_from_directory
 from flask_cors import CORS
@@ -324,7 +328,7 @@ def init_default_mcp_servers():
             )
             db.session.add(usermcp_server)
             db.session.commit()
-            print("初始化内置usermcp服务器配置")
+            logger.info("初始化内置usermcp服务器配置")
         
         # 初始化MCP客户端管理器
         from src.mcp.client import get_mcp_manager
@@ -332,7 +336,7 @@ def init_default_mcp_servers():
         asyncio.run(mcp_manager.initialize_builtin_servers())
         
     except Exception as e:
-        print(f"初始化MCP服务器失败: {e}")
+        logger.error(f"初始化MCP服务器失败: {e}")
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')
@@ -369,9 +373,9 @@ def upgrade_database():
             with db.engine.connect() as connection:
                 connection.execute(text('ALTER TABLE diary_entries ADD COLUMN is_daily_summary BOOLEAN DEFAULT FALSE'))
                 connection.commit()
-            print("数据库升级完成：添加了 is_daily_summary 字段")
+            logger.info("数据库升级完成：添加了 is_daily_summary 字段")
     except Exception as e:
-        print(f"数据库升级失败: {e}")
+        logger.error(f"数据库升级失败: {e}")
         # 如果升级失败，继续运行（可能字段已存在）
         pass
 

--- a/src/services/ai_service.py
+++ b/src/services/ai_service.py
@@ -3,10 +3,13 @@ import base64
 import json
 import re
 import asyncio
+import logging
 from openai import NotFoundError, BadRequestError
 from datetime import datetime
 from src.mcp.client import get_mcp_manager
 from src.models.user import db
+
+logger = logging.getLogger(__name__)
 
 class AIService:
     def __init__(self):
@@ -54,7 +57,7 @@ class AIService:
             else:
                 # 配置不完整或缺少密钥，清除已有实例并打印警告
                 if any([self.client, self.api_url, self.api_key, self.model]):
-                    print("AI配置不完整或缺失，已清除旧的AI客户端配置")
+                    logger.warning("AI配置不完整或缺失，已清除旧的AI客户端配置")
                 self.client = None
                 self.api_url = None
                 self.api_key = None
@@ -65,7 +68,7 @@ class AIService:
             self.api_url = None
             self.api_key = None
             self.model = None
-            print(f"加载AI配置失败: {e}")
+            logger.error(f"加载AI配置失败: {e}")
     
     def _encode_image(self, image_path):
         """将图片编码为base64"""
@@ -73,7 +76,7 @@ class AIService:
             with open(image_path, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode('utf-8')
         except Exception as e:
-            print(f"图片编码失败: {e}")
+            logger.error(f"图片编码失败: {e}")
             return None
 
     def _extract_text_from_message(self, message):
@@ -235,7 +238,7 @@ class AIService:
             return ai_response
             
         except Exception as e:
-            print(f"AI分析失败: {e}")
+            logger.error(f"AI分析失败: {e}")
             return f"AI分析失败: {str(e)}"
     
     def _get_user_context_sync(self, user_id, content):
@@ -255,7 +258,7 @@ class AIService:
                     loop.close()
             return {}
         except Exception as e:
-            print(f"获取用户上下文失败: {e}")
+            logger.error(f"获取用户上下文失败: {e}")
             return {}
     
     async def _get_user_context(self, user_id, content):
@@ -266,7 +269,7 @@ class AIService:
                 return await mcp_manager.query_user_context(user_id, content)
             return {}
         except Exception as e:
-            print(f"获取用户上下文失败: {e}")
+            logger.error(f"获取用户上下文失败: {e}")
             return {}
     
     def _extract_and_store_memories_sync(self, user_id, content, ai_response, image_path=None):
@@ -288,7 +291,7 @@ class AIService:
                     loop.close()
                     
         except Exception as e:
-            print(f"同步提取存储记忆失败: {e}")
+            logger.error(f"同步提取存储记忆失败: {e}")
     
     async def _extract_and_store_memories(self, user_id, content, ai_response, image_path=None):
         """提取并存储用户记忆"""
@@ -311,7 +314,7 @@ class AIService:
                 )
                 
         except Exception as e:
-            print(f"提取存储记忆失败: {e}")
+            logger.error(f"提取存储记忆失败: {e}")
     
     async def _extract_memories_with_ai(self, content, ai_response):
         """使用AI提取记忆信息"""
@@ -359,7 +362,7 @@ class AIService:
                 return self._extract_memories_with_regex(result)
                 
         except Exception as e:
-            print(f"AI提取记忆失败: {e}")
+            logger.error(f"AI提取记忆失败: {e}")
             return []
     
     def _extract_memories_with_regex(self, text):
@@ -388,7 +391,7 @@ class AIService:
             return memories[:3]  # 最多返回3个
             
         except Exception as e:
-            print(f"正则提取记忆失败: {e}")
+            logger.error(f"正则提取记忆失败: {e}")
             return []
     
     def generate_daily_summary(self, entries):
@@ -439,7 +442,7 @@ class AIService:
             )
             
         except Exception as e:
-            print(f"生成日记汇总失败: {e}")
+            logger.error(f"生成日记汇总失败: {e}")
             return f"生成日记汇总失败: {str(e)}"
 
 # 全局AI服务实例

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -7,7 +7,6 @@ from src.services.telegram_service import telegram_service
 from src.services.time_service import time_service
 import logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class SchedulerService:
@@ -139,7 +138,7 @@ class SchedulerService:
             with app.app_context():
                 return self._generate_daily_summary(target_date)
         except Exception as e:
-            print(f"手动生成总结失败: {e}")
+            logger.error(f"手动生成总结失败: {e}")
             return f"服务初始化错误: {str(e)}"
 
     def generate_summary_manually(self, target_date):

--- a/src/services/telegram_service.py
+++ b/src/services/telegram_service.py
@@ -1,5 +1,8 @@
 import requests
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 class TelegramService:
     def __init__(self):
@@ -27,7 +30,7 @@ class TelegramService:
             else:
                 # 配置不完整，清除旧配置
                 if any([self.bot_token, self.chat_id, self.enabled]):
-                    print("Telegram配置不完整，已重置旧值")
+                    logger.warning("Telegram配置不完整，已重置旧值")
                 self.bot_token = None
                 self.chat_id = None
                 self.enabled = False
@@ -36,7 +39,7 @@ class TelegramService:
             self.bot_token = None
             self.chat_id = None
             self.enabled = False
-            print(f"加载Telegram配置失败: {e}")
+            logger.error(f"加载Telegram配置失败: {e}")
     
     def send_message(self, text):
         """发送消息到Telegram"""
@@ -44,7 +47,7 @@ class TelegramService:
         self._load_config()
         
         if not self.enabled or not self.bot_token or not self.chat_id:
-            print("Telegram服务未启用或配置不完整")
+            logger.warning("Telegram服务未启用或配置不完整")
             return False
         
         try:
@@ -57,16 +60,16 @@ class TelegramService:
             }
             
             response = requests.post(url, json=payload, timeout=10)
-            
+
             if response.status_code == 200:
-                print("Telegram消息发送成功")
+                logger.info("Telegram消息发送成功")
                 return True
             else:
-                print(f"Telegram消息发送失败: {response.status_code} - {response.text}")
+                logger.error(f"Telegram消息发送失败: {response.status_code} - {response.text}")
                 return False
-                
+
         except Exception as e:
-            print(f"发送Telegram消息异常: {e}")
+            logger.error(f"发送Telegram消息异常: {e}")
             return False
     
     def send_daily_summary(self, date, summary_content, entry_count):
@@ -90,9 +93,9 @@ class TelegramService:
 来自杯子日记"""
             
             return self.send_message(message)
-            
+
         except Exception as e:
-            print(f"发送每日汇总失败: {e}")
+            logger.error(f"发送每日汇总失败: {e}")
             return False
     
     def test_connection(self):


### PR DESCRIPTION
## Summary
- initialize UTF-8 capable logging at application startup
- log diagnostic output in AI, Telegram, scheduler, and diary services instead of printing

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895e54801d883309608bf0e46354df6